### PR TITLE
add minimalist dev tooling Vagrantfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,14 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+PROVISION_SCRIPT = <<SCRIPT
+  pacman -Sy --noconfirm go
+SCRIPT
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "terrywang/archlinux"
+  config.vm.provision "shell", inline: PROVISION_SCRIPT
+end


### PR DESCRIPTION
This PR adds a basic Vagrantfile to the repo so that you can get started playing with Go without having to do any manual installation steps for the Go toolchain.
