### PR TITLE
remove underscore from package name and some variables

### DIFF
--- a/about_allocation.go
+++ b/about_allocation.go
@@ -1,4 +1,4 @@
-package go_koans
+package gokoans
 
 func aboutAllocation() {
 	a := new(int)

--- a/about_anonymous_functions.go
+++ b/about_anonymous_functions.go
@@ -1,4 +1,4 @@
-package go_koans
+package gokoans
 
 func aboutAnonymousFunctions() {
 	{

--- a/about_arrays.go
+++ b/about_arrays.go
@@ -1,4 +1,4 @@
-package go_koans
+package gokoans
 
 func aboutArrays() {
 	fruits := [4]string{"apple", "orange", "mango"}
@@ -13,14 +13,14 @@ func aboutArrays() {
 
 	assert(fruits == [4]string{}) // comparing arrays is not like comparing apples and oranges
 
-	tasty_fruits := fruits[1:3]           // defining oneself as a variation of another
-	assert(tasty_fruits[0] == __string__) // slices of arrays share some data
-	assert(tasty_fruits[1] == __string__) // albeit slightly askewed
+	tastyFruits := fruits[1:3]           // defining oneself as a variation of another
+	assert(tastyFruits[0] == __string__) // slices of arrays share some data
+	assert(tastyFruits[1] == __string__) // albeit slightly askewed
 
-	assert(len(tasty_fruits) == __int__) // its length is manifest
-	assert(cap(tasty_fruits) == __int__) // but its capacity is surprising!
+	assert(len(tastyFruits) == __int__) // its length is manifest
+	assert(cap(tastyFruits) == __int__) // but its capacity is surprising!
 
-	tasty_fruits[0] = "lemon" // are their shared roots truly identical?
+	tastyFruits[0] = "lemon" // are their shared roots truly identical?
 
 	assert(fruits[0] == __string__) // has this element remained the same?
 	assert(fruits[1] == __string__) // how about the second?

--- a/about_basics.go
+++ b/about_basics.go
@@ -1,4 +1,4 @@
-package go_koans
+package gokoans
 
 func aboutBasics() {
 	assert(__bool__ == true)  // what is truth?

--- a/about_channels.go
+++ b/about_channels.go
@@ -1,4 +1,4 @@
-package go_koans
+package gokoans
 
 func aboutChannels() {
 	ch := make(chan string, 2)

--- a/about_common_interfaces.go
+++ b/about_common_interfaces.go
@@ -1,4 +1,4 @@
-package go_koans
+package gokoans
 
 import "bytes"
 

--- a/about_concurrency.go
+++ b/about_concurrency.go
@@ -1,4 +1,4 @@
-package go_koans
+package gokoans
 
 func isPrimeNumber(possiblePrime int) bool {
 	for underPrime := 2; underPrime < possiblePrime; underPrime++ {

--- a/about_control_flow.go
+++ b/about_control_flow.go
@@ -1,4 +1,4 @@
-package go_koans
+package gokoans
 
 import "fmt"
 

--- a/about_enumeration.go
+++ b/about_enumeration.go
@@ -1,4 +1,4 @@
-package go_koans
+package gokoans
 
 func aboutEnumeration() {
 	{

--- a/about_files.go
+++ b/about_files.go
@@ -1,4 +1,4 @@
-package go_koans
+package gokoans
 
 import "io/ioutil"
 import "strings"

--- a/about_interfaces.go
+++ b/about_interfaces.go
@@ -1,4 +1,4 @@
-package go_koans
+package gokoans
 
 func aboutInterfaces() {
 	bob := new(human)     // bob is a kind of *human

--- a/about_maps.go
+++ b/about_maps.go
@@ -1,4 +1,4 @@
-package go_koans
+package gokoans
 
 func aboutMaps() {
 	ages := map[string]int{

--- a/about_panics.go
+++ b/about_panics.go
@@ -1,4 +1,4 @@
-package go_koans
+package gokoans
 
 func divideFourBy(i int) int {
 	return 4 / i

--- a/about_pointers.go
+++ b/about_pointers.go
@@ -1,4 +1,4 @@
-package go_koans
+package gokoans
 
 func aboutPointers() {
 	{

--- a/about_slices.go
+++ b/about_slices.go
@@ -1,4 +1,4 @@
-package go_koans
+package gokoans
 
 func aboutSlices() {
 	fruits := []string{"apple", "orange", "mango"}
@@ -6,18 +6,18 @@ func aboutSlices() {
 	assert(fruits[0] == __string__) // slices seem like arrays
 	assert(len(fruits) == __int__)  // in nearly all respects
 
-	tasty_fruits := fruits[1:3]           // we can even slice slices
-	assert(tasty_fruits[0] == __string__) // slices of slices also share the underlying data
+	tastyFruits := fruits[1:3]           // we can even slice slices
+	assert(tastyFruits[0] == __string__) // slices of slices also share the underlying data
 
-	pregnancy_slots := []string{"baby", "baby", "lemon"}
-	assert(cap(pregnancy_slots) == __int__) // the capacity is initially the length
+	pregnancySlots := []string{"baby", "baby", "lemon"}
+	assert(cap(pregnancySlots) == __int__) // the capacity is initially the length
 
-	pregnancy_slots = append(pregnancy_slots, "baby!")
-	assert(len(pregnancy_slots) == __int__) // slices can be extended with append(), much like realloc in C
-	assert(cap(pregnancy_slots) == __int__) // but with better optimizations
+	pregnancySlots = append(pregnancySlots, "baby!")
+	assert(len(pregnancySlots) == __int__) // slices can be extended with append(), much like realloc in C
+	assert(cap(pregnancySlots) == __int__) // but with better optimizations
 
-	pregnancy_slots = append(pregnancy_slots, "another baby!?", "yet another, oh dear!", "they must be Catholic")
+	pregnancySlots = append(pregnancySlots, "another baby!?", "yet another, oh dear!", "they must be Catholic")
 
-	assert(len(pregnancy_slots) == __int__) // append() can take N arguments to append to the slice
-	assert(cap(pregnancy_slots) == __int__) // the capacity optimizations have a guessable algorithm
+	assert(len(pregnancySlots) == __int__) // append() can take N arguments to append to the slice
+	assert(cap(pregnancySlots) == __int__) // the capacity optimizations have a guessable algorithm
 }

--- a/about_strings.go
+++ b/about_strings.go
@@ -1,4 +1,4 @@
-package go_koans
+package gokoans
 
 import "fmt"
 

--- a/about_structs.go
+++ b/about_structs.go
@@ -1,4 +1,4 @@
-package go_koans
+package gokoans
 
 func aboutStructs() {
 	var bob struct {

--- a/about_types.go
+++ b/about_types.go
@@ -1,4 +1,4 @@
-package go_koans
+package gokoans
 
 type coolNumber int
 

--- a/about_variadic_functions.go
+++ b/about_variadic_functions.go
@@ -1,4 +1,4 @@
-package go_koans
+package gokoans
 
 import "strings"
 

--- a/setup_koans_test.go
+++ b/setup_koans_test.go
@@ -1,4 +1,4 @@
-package go_koans
+package gokoans
 
 import (
 	"fmt"


### PR DESCRIPTION
this prevents go-plus warnings in atom editor and i believe the naming convention rules for golang.