### PR TITLE
Reset text color after printing congratulatory message.

### DIFF
--- a/setup_koans_test.go
+++ b/setup_koans_test.go
@@ -44,7 +44,7 @@ func TestKoans(t *testing.T) {
 	aboutConcurrency()
 	aboutPanics()
 
-	fmt.Printf("\n%c[32;1mYou won life. Good job.\n\n", 27)
+	fmt.Printf("\n%c[32;1mYou won life. Good job.%c[0m\n\n", 27, 27)
 }
 
 func assert(o bool) {


### PR DESCRIPTION
For users who don't have color codes in their prompts, text in the terminal is green after completing the koans.