### PR TITLE
Removed use of self

### DIFF
--- a/about_interfaces.go
+++ b/about_interfaces.go
@@ -33,8 +33,8 @@ type human struct {
 	milesCompleted int
 }
 
-func (self *human) run() {
-	self.milesCompleted++
+func (h *human) run() {
+	h.milesCompleted++
 }
 
 // another concrete type implementing the interface
@@ -43,6 +43,6 @@ type program struct {
 	executionCount int
 }
 
-func (self *program) run() {
-	self.executionCount++
+func (p *program) run() {
+	p.executionCount++
 }


### PR DESCRIPTION
I believe it's unidiomatic to use `self` as a receiver name in Go, so amended it, especially as this is (a pretty amazing) learning resource which will be viewed by many new people.