### PR TITLE
Rename gokoans pkg to avoid underscore

### DIFF
--- a/about_allocation.go
+++ b/about_allocation.go
@@ -1,4 +1,4 @@
-package go_koans
+package gokoans
 
 func aboutAllocation() {
 	a := new(int)

--- a/about_anonymous_functions.go
+++ b/about_anonymous_functions.go
@@ -1,4 +1,4 @@
-package go_koans
+package gokoans
 
 func aboutAnonymousFunctions() {
 	{

--- a/about_arrays.go
+++ b/about_arrays.go
@@ -1,4 +1,4 @@
-package go_koans
+package gokoans
 
 import "fmt"
 

--- a/about_basics.go
+++ b/about_basics.go
@@ -1,4 +1,4 @@
-package go_koans
+package gokoans
 
 func aboutBasics() {
 	assert(__bool__ == true)  // what is truth?

--- a/about_channels.go
+++ b/about_channels.go
@@ -1,4 +1,4 @@
-package go_koans
+package gokoans
 
 func aboutChannels() {
 	ch := make(chan string, 2)

--- a/about_common_interfaces.go
+++ b/about_common_interfaces.go
@@ -1,4 +1,4 @@
-package go_koans
+package gokoans
 
 import "bytes"
 

--- a/about_concurrency.go
+++ b/about_concurrency.go
@@ -1,4 +1,4 @@
-package go_koans
+package gokoans
 
 func isPrimeNumber(possiblePrime int) bool {
 	for underPrime := 2; underPrime < possiblePrime; underPrime++ {

--- a/about_control_flow.go
+++ b/about_control_flow.go
@@ -1,4 +1,4 @@
-package go_koans
+package gokoans
 
 import "fmt"
 

--- a/about_defer.go
+++ b/about_defer.go
@@ -1,4 +1,4 @@
-package go_koans
+package gokoans
 
 func aboutDefer() {
 	var acc int

--- a/about_enumeration.go
+++ b/about_enumeration.go
@@ -1,4 +1,4 @@
-package go_koans
+package gokoans
 
 func aboutEnumeration() {
 	{

--- a/about_files.go
+++ b/about_files.go
@@ -1,4 +1,4 @@
-package go_koans
+package gokoans
 
 import "io/ioutil"
 import "strings"

--- a/about_interfaces.go
+++ b/about_interfaces.go
@@ -1,4 +1,4 @@
-package go_koans
+package gokoans
 
 func aboutInterfaces() {
 	bob := new(human)     // bob is a kind of *human

--- a/about_maps.go
+++ b/about_maps.go
@@ -1,4 +1,4 @@
-package go_koans
+package gokoans
 
 func aboutMaps() {
 	ages := map[string]int{

--- a/about_panics.go
+++ b/about_panics.go
@@ -1,4 +1,4 @@
-package go_koans
+package gokoans
 
 func divideFourBy(i int) int {
 	return 4 / i

--- a/about_pointers.go
+++ b/about_pointers.go
@@ -1,4 +1,4 @@
-package go_koans
+package gokoans
 
 func aboutPointers() {
 	{

--- a/about_slices.go
+++ b/about_slices.go
@@ -1,4 +1,4 @@
-package go_koans
+package gokoans
 
 func aboutSlices() {
 	fruits := []string{"apple", "orange", "mango"}

--- a/about_strings.go
+++ b/about_strings.go
@@ -1,4 +1,4 @@
-package go_koans
+package gokoans
 
 import "fmt"
 

--- a/about_structs.go
+++ b/about_structs.go
@@ -1,4 +1,4 @@
-package go_koans
+package gokoans
 
 func aboutStructs() {
 	var bob struct {

--- a/about_types.go
+++ b/about_types.go
@@ -1,4 +1,4 @@
-package go_koans
+package gokoans
 
 type coolNumber int
 

--- a/about_variadic_functions.go
+++ b/about_variadic_functions.go
@@ -1,4 +1,4 @@
-package go_koans
+package gokoans
 
 import "strings"
 

--- a/setup_koans_test.go
+++ b/setup_koans_test.go
@@ -1,4 +1,4 @@
-package go_koans
+package gokoans
 
 import (
 	"fmt"


### PR DESCRIPTION
Similar to https://github.com/cdarwin/go-koans/pull/9 without the variable renames. Was required for `about_allocations.go` to find `assert()` which really makes no sense.