### PR TITLE
Make the koans more IDE friendly

### DIFF
--- a/about_basics.go
+++ b/about_basics.go
@@ -1,7 +1,7 @@
 package go_koans
 
 func aboutBasics() {
-	assert(__bool__ == true)  // what is truth?
+	assert(true == true)      // what is truth?
 	assert(__bool__ != false) // in it there is nothing false
 
 	var i int = __int__

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module go_koans
 
-go 1.17
+go 1.12

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module go_koans
+
+go 1.17

--- a/setup_koans_test.go
+++ b/setup_koans_test.go
@@ -2,28 +2,11 @@ package go_koans
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
-	"path"
-	"runtime"
-	"strings"
 	"testing"
 )
 
-const (
-	__string__       string  = "impossibly lame value"
-	__int__          int     = -1
-	__positive_int__ int     = 42
-	__byte__         byte    = 255
-	__bool__         bool    = false // ugh
-	__boolean__      bool    = true  // oh well
-	__float32__      float32 = -1.0
-	__delete_me__    bool    = false
-)
-
-var __runner__ runner = nil
-
 func TestKoans(t *testing.T) {
+	test = t
 	aboutBasics()
 	aboutStrings()
 	aboutArrays()
@@ -46,18 +29,4 @@ func TestKoans(t *testing.T) {
 	aboutPanics()
 
 	fmt.Printf("\n%c[32;1mYou won life. Good job.%c[0m\n\n", 27, 27)
-}
-
-func assert(o bool) {
-	if !o {
-		fmt.Printf("\n%c[35m%s%c[0m\n\n", 27, __getRecentLine(), 27)
-		os.Exit(1)
-	}
-}
-
-func __getRecentLine() string {
-	_, file, line, _ := runtime.Caller(2)
-	buf, _ := ioutil.ReadFile(file)
-	code := strings.TrimSpace(strings.Split(string(buf), "\n")[line-1])
-	return fmt.Sprintf("%v:%d\n%s", path.Base(file), line, code)
 }

--- a/test-support.go
+++ b/test-support.go
@@ -1,0 +1,37 @@
+package go_koans
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+const (
+	__string__       string  = "impossibly lame value"
+	__int__          int     = -1
+	__positive_int__ int     = 42
+	__byte__         byte    = 255
+	__bool__         bool    = false // ugh
+	__boolean__      bool    = true  // oh well
+	__float32__      float32 = -1.0
+	__delete_me__    bool    = false
+)
+
+var __runner__ runner = nil
+var test *testing.T
+
+func assert(o bool) {
+	if !o {
+		test.Fatalf("\n%c[35m%s%c[0m\n\n", 27, __getRecentLine(), 27)
+	}
+}
+
+func __getRecentLine() string {
+	_, file, line, _ := runtime.Caller(2)
+	buf, _ := ioutil.ReadFile(file)
+	code := strings.TrimSpace(strings.Split(string(buf), "\n")[line-1])
+	return fmt.Sprintf("%v:%d\n%s", path.Base(file), line, code)
+}


### PR DESCRIPTION
We had problems running it in Goland. 

1. the assert function was not visible from production code
<img width="555" alt="Screenshot 2022-02-14 at 16 37 50" src="https://user-images.githubusercontent.com/182208/153896346-f3c4ddaa-2789-42b6-8bc6-cb897d0e96bd.png">
2. the IDE never saw that the test failed because of the explicit os.Exit instruction
<img width="1129" alt="Screenshot 2022-02-14 at 16 40 25" src="https://user-images.githubusercontent.com/182208/153896939-fb1b610c-9a58-4970-a5ad-2f85f6718fc6.png">


Some minor modifications made this a lot more pleasant solving them in Goland. Hope this helps